### PR TITLE
add index.ts file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "index.ts"
   ],
   "scripts": {
     "transpile": "tsc",


### PR DESCRIPTION
This removes warning:
`WARNING in ./node_modules/get-own-enumerable-property-symbols/lib/index.js
(Emitted value instead of an instance of Error) Cannot find source file '../index.ts': Error: Can't resolve '../index.ts' in ...`