### PR TITLE
build: change transpile target for IE11 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": [
       "node"
-    ]
+    ],
+    "target": "es5"
   }
 }


### PR DESCRIPTION
This package has made its way into Storybook as a deep nested dependency and there is a need to test components in IE11.

This PR changes the transpile target from es2015 to es5 so that IE11 is happy

